### PR TITLE
Optimize free-staffs query*

### DIFF
--- a/app/models/engineering_projects_staff.rb
+++ b/app/models/engineering_projects_staff.rb
@@ -1,0 +1,2 @@
+class EngineeringProjectsStaff < ActiveRecord::Base
+end

--- a/app/models/engineering_staff.rb
+++ b/app/models/engineering_staff.rb
@@ -229,6 +229,14 @@ class EngineeringStaff < ActiveRecord::Base
     raise "时间检查失败：#{ret}" if ret.present?
   end
 
+  def accept_schedule_with_time_range?(start_date, end_date, time_range)
+    time_range.each do |range|
+      return false unless range[0] > end_date.to_date || range[1] < start_date.to_date
+    end
+
+    return true
+  end
+
   def accept_schedule?(start_date, end_date)
     # if birth.present? && start_date < birth + 18.years
     #   return "员工未满十八周岁，员工生日 #{birth}"


### PR DESCRIPTION
```rb
def foo(project_id)
  project = EngineeringProject.find(project_id)

  customer = project.customer
  start_date, end_date = project.range

  criteria = customer.staffs.enabled
  es_ids = criteria.pluck(:id)

  project_ids = pre_calculate_project_ids(es_ids)
  ranges = pre_calculate_ranges(es_ids)

  a = criteria.lazy.select do |es|
    !(project_ids[es.id].include? project_id) \
      && es.accept_schedule_with_time_range?(start_date, end_date, ranges[es.id])
  end

  st = Time.now
  ed = Time.now
  puts "st: #{st}, ed: #{ed} takes: #{ed - st}s"

  return a.count
end

st = Time.now
foo(project_id) # 1146
ed = Time.now
puts "st: #{st}, ed: #{ed} takes: #{ed - st}s"
```

Before:
st: 2019-03-12 04:14:44 +0800, ed: 2019-03-12 04:15:04 +0800 takes: 20.454014773s

After:
st: 2019-03-12 04:59:57 +0800, ed: 2019-03-12 04:59:59 +0800 takes: 2.220440217s